### PR TITLE
Tag artifacts with product version (resolves #3)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                     BUILD_VERSION = sh(
                             returnStdout: true,
                             script: 'echo $(node -e "console.log(require(\'./package.json\').version)")'
-                    )
+                    ).replace('\n', '')
                     env.BUILD_VERSION = BUILD_VERSION
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-circle",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-circle",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A google.maps.Circle replacement for Mapbox GL JS API",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "main": "main.js",
   "scripts": {
     "start": "budo example/index.js --live -- -t brfs ",
-    "watchify": "mkdir -p dist && watchify lib/main.js -o dist/mapbox-gl-circle.js --debug -v",
-    "browserify": "mkdir -p dist && browserify lib/main.js -o dist/mapbox-gl-circle.js --debug --delay=0 -v",
-    "prepare": "mkdir -p dist && browserify --standalone MapboxCircle -t [ babelify --presets [ es2015 ] ] lib/main.js | uglifyjs -c -m > dist/mapbox-gl-circle.min.js",
+    "watchify": "mkdir -p dist && watchify lib/main.js -o dist/mapbox-gl-circle-${BUILD_VERSION:-dev}.js --debug -v",
+    "browserify": "mkdir -p dist && browserify lib/main.js -o dist/mapbox-gl-circle-${BUILD_VERSION:-dev}.js --debug --delay=0 -v",
+    "prepare": "mkdir -p dist && browserify --standalone MapboxCircle -t [ babelify --presets [ es2015 ] ] lib/main.js | uglifyjs -c -m > dist/mapbox-gl-circle-${BUILD_VERSION:-dev}.min.js",
     "docs": "documentation build lib/main.js --format=md > API.md",
-    "test": "eslint lib",
     "lint": "eslint lib"
   },
   "browserify": {


### PR DESCRIPTION
Builds are now produced with product version as part of the file name, e.g. `mapbox-gl-circle-1.2.1.min.js` (see http://jenkins.smithmicro.io:8080/blue/organizations/jenkins/mapbox-gl-circle-multibranch/detail/tag-artifacts-with-product-version/7/artifacts for proof).