### PR TITLE
Tag builds with SemVer pre-release versions and build metadata (closes #4, closes #5 and closes #6)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,10 +22,8 @@ pipeline {
                         }
 
                         if (fullBranchName ==~ ~/(feature|bugfix)\/[.\d\-\w]+$/) {
-                            String _type, _name
-                            (_type, _name) = fullBranchName.split('/') as List
-                            return [_type as String,
-                                    _name.replaceAll(/[^.\da-zA-Z]/, '.').toLowerCase()]
+                            return [fullBranchName.split('/')[0],
+                                    fullBranchName.split('/')[1].toLowerCase().replaceAll(/[^.\da-z]/, '.')]
                         }
 
                         if (fullBranchName ==~ ~/hotfix\/\d+(\.\d+){1,2}p\d+$/) {
@@ -40,22 +38,22 @@ pipeline {
                     }
 
                     def getBuildVersion = { String fullBranchName, buildNumber ->
-                        String branchType, branchName, projectVersion = getProjectVersion()
-                        (branchType, branchName) = getBranchTypeAndName(fullBranchName)
+                        String projectVersion = getProjectVersion()
+                        def branchTypeAndName = getBranchTypeAndName(fullBranchName)
 
-                        switch (branchType) {
+                        switch (branchTypeAndName[0]) {
                             case 'master':
                                 return projectVersion
                             case 'hotfix':
-                                return "${branchName}-rc.${buildNumber}"
+                                return "${branchTypeAndName[1]}-rc.${buildNumber}"
                             case 'develop':
                                 return "${projectVersion}+develop.dev${buildNumber}"
                             case 'feature':
-                                return "${projectVersion}+feature.${branchName}.dev${buildNumber}"
+                                return "${projectVersion}+feature.${branchTypeAndName[1]}.dev${buildNumber}"
                             case 'bugfix':
-                                return "${projectVersion}+bugfix.${branchName}.dev${buildNumber}"
+                                return "${projectVersion}+bugfix.${branchTypeAndName[1]}.dev${buildNumber}"
                             case 'release':
-                                assert branchName == projectVersion
+                                assert branchTypeAndName[1] == projectVersion
                                 return "${projectVersion}-rc.${buildNumber}"
                             default:
                                 throw new AssertionError("Oops, Mats messed up! :(")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,62 @@ pipeline {
         stage('Set BUILD_VERSION') {
             steps {
                 script {
-                    env.BUILD_VERSION = sh(
-                            returnStdout: true,
-                            script: 'echo $(node -e "console.log(require(\'./package.json\').version)")'
-                    ).replace('\n', '')
+
+                    def getProjectVersion = { ->
+                        return sh(
+                                returnStdout: true,
+                                script: 'echo $(node -e "console.log(require(\'./package.json\').version)")'
+                        ).replace('\n', '')
+                    }
+
+                    def getBranchTypeAndName = { String fullBranchName ->
+
+                        if (fullBranchName in ['develop', 'master']) {
+                            return [fullBranchName, fullBranchName]
+                        }
+
+                        if (fullBranchName ==~ ~/(feature|bugfix)\/[.\d\-\w]+$/) {
+                            String _type, _name
+                            (_type, _name) = fullBranchName.split('/') as List
+                            return [_type as String,
+                                    _name.replaceAll(/[^.\da-zA-Z]/, '.').toLowerCase()]
+                        }
+
+                        if (fullBranchName ==~ ~/hotfix\/\d+(\.\d+){1,2}p\d+$/) {
+                            return fullBranchName.split('/') as List
+                        }
+
+                        if (fullBranchName ==~ ~/release\/\d+(\.\d+){1,2}([ab]\d+)?$/) {
+                            return fullBranchName.split('/') as List
+                        }
+
+                        throw new AssertionError("Enforcing Gitflow Workflow and SemVer. Ha!")
+                    }
+
+                    def getBuildVersion = { String fullBranchName, buildNumber ->
+                        String branchType, branchName, projectVersion = getProjectVersion()
+                        (branchType, branchName) = getBranchTypeAndName(fullBranchName)
+
+                        switch (branchType) {
+                            case 'master':
+                                return projectVersion
+                            case 'hotfix':
+                                return "${branchName}-rc.${buildNumber}"
+                            case 'develop':
+                                return "${projectVersion}+develop.dev${buildNumber}"
+                            case 'feature':
+                                return "${projectVersion}+feature.${branchName}.dev${buildNumber}"
+                            case 'bugfix':
+                                return "${projectVersion}+bugfix.${branchName}.dev${buildNumber}"
+                            case 'release':
+                                assert branchName == projectVersion
+                                return "${projectVersion}-rc.${buildNumber}"
+                            default:
+                                throw new AssertionError("Oops, Mats messed up! :(")
+                        }
+                    }
+
+                    env.BUILD_VERSION = getBuildVersion(BRANCH_NAME as String, BUILD_NUMBER)
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,16 +21,16 @@ pipeline {
                             return [fullBranchName, fullBranchName]
                         }
 
-                        if (fullBranchName ==~ ~/(feature|bugfix)\/[.\d\-\w]+$/) {
+                        if (fullBranchName.matches(/(feature|bugfix)\/[.\d\-\w]+$/)) {
                             return [fullBranchName.split('/')[0],
                                     fullBranchName.split('/')[1].toLowerCase().replaceAll(/[^.\da-z]/, '.')]
                         }
 
-                        if (fullBranchName ==~ ~/hotfix\/\d+(\.\d+){1,2}p\d+$/) {
+                        if (fullBranchName.matches(/hotfix\/\d+(\.\d+){1,2}p\d+$/)) {
                             return fullBranchName.split('/') as List
                         }
 
-                        if (fullBranchName ==~ ~/release\/\d+(\.\d+){1,2}([ab]\d+)?$/) {
+                        if (fullBranchName.matches(/release\/\d+(\.\d+){1,2}([ab]\d+)?$/)) {
                             return fullBranchName.split('/') as List
                         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
                     }
 
                     env.BUILD_VERSION = getBuildVersion(BRANCH_NAME as String, BUILD_NUMBER)
+                    env.DOCKER_TAG = env.BUILD_VERSION.replace('+', '_')
                 }
             }
         }
@@ -99,8 +100,8 @@ pipeline {
                 parallel(
                         'Docker Image': {
                             sh 'rm -rf node_modules'
-                            sh 'docker build -t docker.smithmicro.io/mapbox-gl-circle:$BUILD_VERSION .'
-                            sh '''docker save docker.smithmicro.io/mapbox-gl-circle:$BUILD_VERSION | gzip - \
+                            sh 'docker build -t docker.smithmicro.io/mapbox-gl-circle:$DOCKER_TAG .'
+                            sh '''docker save docker.smithmicro.io/mapbox-gl-circle:$DOCKER_TAG | gzip - \
 > mapbox-gl-circle-$BUILD_VERSION.docker.tar.gz'''
                             archiveArtifacts "mapbox-gl-circle-${BUILD_VERSION}.docker.tar.gz"
                         },


### PR DESCRIPTION
How it works, assuming current release 1.2.1 and build number 5 according to Jenkins:

```groovy
println(getBuildVersion('master', 5))
"1.2.1"

println(getBuildVersion('hotfix/1.2.0p1', 5))
"1.2.0p1-rc.5"

println(getBuildVersion('develop', 5))
"1.2.1+develop.dev5"

println(getBuildVersion('feature/I-want-a-sandwich-n0w', 5))
"1.2.1+feature.i.want.a.sandwich.n0w.dev5"

println(getBuildVersion('bugfix/issue-6', 5))
"1.2.1+bugfix.issue.6.dev5"

println(getBuildVersion('release/1.2.1', 5))
"1.2.1-rc.5"
```
