### PR TITLE
Set layer order

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Returns **[MapboxCircle](#mapboxcircle)**
 **Parameters**
 
 -   `map` **mapboxgl.Map** Target map for adding and initializing circle Mapbox GL layers/data/listeners.
+-   `before` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** ID of an existing layer to insert the new circle layer before. If this argument is omitted, the circle layer will be appended to the end of the layers array. (optional, default `undefined`)
 
 Returns **[MapboxCircle](#mapboxcircle)** 
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -933,20 +933,20 @@ class MapboxCircle {
      * @return {MapboxCircle}
      * @public
      */
-    addTo(map) {
+    addTo(map, before) {
         const addCircleAssetsOnMap = () => {
             map.addSource(this._circleSourceId, this._getMapSourceGeoJSON());
 
-            map.addLayer(this._getCircleStrokeLayer(), 'waterway-label');
-            map.addLayer(this._getCircleFillLayer(), 'waterway-label');
+            map.addLayer(this._getCircleStrokeLayer(), before);
+            map.addLayer(this._getCircleFillLayer(), before);
             this._bindCircleFillListeners(map);
             map.on('zoomend', this._onZoomEnd);
 
             if (this.options.editable) {
-                map.addLayer(this._getCircleCenterHandleLayer());
+                map.addLayer(this._getCircleCenterHandleLayer(), before);
                 this._bindCenterHandleListeners(map);
 
-                map.addLayer(this._getCircleRadiusHandlesLayer());
+                map.addLayer(this._getCircleRadiusHandlesLayer(), before);
                 this._bindRadiusHandlesListeners(map);
 
                 this.on('centerchanged', this._onCenterChanged).on('radiuschanged', this._onRadiusChanged);


### PR DESCRIPTION
This change implements a fix for https://github.com/mblomdahl/mapbox-gl-circle/issues/50 by allowing the user to pass a layer id `<String>` as the second argument to the `addTo` method. Leaving out this argument will append the layer to the end of the layers array; otherwise, the circle will appear directly before the layer specified in the argument.