### PR TITLE
Feature/DebounceAnimation

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -239,6 +239,7 @@ class MapboxCircle {
         /** @const {Array<Point>} */ this._handles = undefined;
         /** @const {boolean} */ this._centerDragActive = false;
         /** @const {boolean} */ this._radiusDragActive = false;
+        /** @const {Object} */ this._debouncedHandlers = {};
         /** @const {number} */ this._updateCount = 0;
 
         [ // Bind all event handlers.
@@ -281,6 +282,27 @@ class MapboxCircle {
      */
     static _checkIfBrowserIsSafari() {
         return window.navigator.userAgent.indexOf('Chrome') === -1 && window.navigator.userAgent.indexOf('Safari') > -1;
+    }
+
+    /**
+     * Add debounced event handler to map.
+     * @param {string} event Mapbox GL event name
+     * @param {Function} handler Event handler
+     * @private
+     */
+    _mapOnDebounced(event, handler) {
+        this._debouncedHandlers[handler] = _.debounce(handler, 6, {leading: false, trailing: true});
+        this.map.on(event, this._debouncedHandlers[handler]);
+    }
+
+    /**
+     * Remove debounced event handler from map.
+     * @param {string} event Mapbox GL event name
+     * @param {Function} handler Event handler
+     * @private
+     */
+    _mapOffDebounced(event, handler) {
+        this.map.off(event, this._debouncedHandlers[handler]);
     }
 
     /**
@@ -471,7 +493,7 @@ class MapboxCircle {
      */
     _onCenterHandleMouseDown() {
         this._centerDragActive = true;
-        this.map.on('mousemove', this._onCenterHandleMouseMove);
+        this._mapOnDebounced('mousemove', this._onCenterHandleMouseMove);
         this.map.addLayer(this._getCenterHandleStrokeLayer(), this._circleCenterHandleId);
         this._suspendHandleListeners('center');
         this.map.once('mouseup', this._onCenterHandleMouseUpOrMapMouseOut);
@@ -510,7 +532,7 @@ class MapboxCircle {
 
         const newCenter = this.center;
         this._centerDragActive = false;
-        this.map.off('mousemove', this._onCenterHandleMouseMove);
+        this._mapOffDebounced('mousemove', this._onCenterHandleMouseMove);
         switch (event.type) {
             case 'mouseup': this.map.off('mouseout', this._onCenterHandleMouseUpOrMapMouseOut); break;
             case 'mouseout': this.map.off('mouseup', this._onCenterHandleMouseUpOrMapMouseOut); break;
@@ -610,7 +632,7 @@ class MapboxCircle {
      */
     _onRadiusHandlesMouseDown(event) {
         this._radiusDragActive = true;
-        this.map.on('mousemove', this._onRadiusHandlesMouseMove);
+        this._mapOnDebounced('mousemove', this._onRadiusHandlesMouseMove);
         this.map.addLayer(this._getRadiusHandlesStrokeLayer(), this._circleRadiusHandlesId);
         this._suspendHandleListeners('radius');
         this.map.once('mouseup', this._onRadiusHandlesMouseUpOrMapMouseOut);
@@ -649,7 +671,7 @@ class MapboxCircle {
 
         const newRadius = this.radius;
         this._radiusDragActive = false;
-        this.map.off('mousemove', this._onRadiusHandlesMouseMove);
+        this._mapOffDebounced('mousemove', this._onRadiusHandlesMouseMove);
         this.map.removeLayer(this._circleRadiusHandlesStrokeId);
         switch (event.type) {
             case 'mouseup': this.map.off('mouseout', this._onRadiusHandlesMouseUpOrMapMouseOut); break;

--- a/lib/main.js
+++ b/lib/main.js
@@ -239,6 +239,7 @@ class MapboxCircle {
         /** @const {Array<Point>} */ this._handles = undefined;
         /** @const {boolean} */ this._centerDragActive = false;
         /** @const {boolean} */ this._radiusDragActive = false;
+        /** @const {number} */ this._updateCount = 0;
 
         [ // Bind all event handlers.
             '_onZoomEnd',
@@ -306,9 +307,11 @@ class MapboxCircle {
         }
 
         if (this.options.debugEl) {
+            this._updateCount += 1;
             this.options.debugEl.innerHTML = ('Center: ' + JSON.stringify(this.getCenter()) + ' / Radius: ' + radius +
                                               ' / Bounds: ' + JSON.stringify(this.getBounds()) + ' / Steps: ' + steps +
-                                              ' / Zoom: ' + zoom.toFixed(2) + ' / ID: ' + this._instanceId);
+                                              ' / Zoom: ' + zoom.toFixed(2) + ' / ID: ' + this._instanceId +
+                                              ' / #: ' + this._updateCount);
         }
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -291,7 +291,16 @@ class MapboxCircle {
      * @private
      */
     _mapOnDebounced(event, handler) {
-        this._debouncedHandlers[handler] = _.debounce(handler, 6, {leading: false, trailing: true});
+        let ticking = false;
+        this._debouncedHandlers[handler] = (args) => {
+                if (!ticking) {
+                    requestAnimationFrame(() => {
+                        handler(args);
+                        ticking = false;
+                    });
+                }
+                ticking = true;
+            };
         this.map.on(event, this._debouncedHandlers[handler]);
     }
 


### PR DESCRIPTION
This (largely) fixes mapbox/smithmicro-collab#1 (and also fixes #64 and fixes #59).

Initial approach with `_.debounce` was somewhat successful; after lots of tweaking and benchmarking in ...
- Firefox/Safari on 15" MacBook Pro (with and without discrete GPU running)
- Firefox/Edge on Windows 10 laptop from 2014 with Core i3 CPU, 4 GB and spinning junk inside

... I found the magic compromise to be trailing lodash debounce at 6 ms. More milliseconds and it becomes unnecessarily laggy and unresponsive on fast laptop. Less and performance **really** degrades on crappy computers.

In the end, lodash.debounce still came with a degraded user experience on fast machines so I gave up on it and resorted to rAF instead. With requestAnimationFrame things seem to run smoothly on the Mac and even better than _.debounce on the worst performing setup (Firefox + i3 + Windows 10).
