### PR TITLE
Add radiuschanging and centerchanging events

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -154,6 +154,7 @@ class MapboxCircle {
             this._currentCenterLngLat[0] = newCenter[0];
             this._currentCenterLngLat[1] = newCenter[1];
         }
+        this._eventEmitter.emit('centerchanging', this);
         this._updateCircle();
         this._animate();
     }
@@ -170,6 +171,7 @@ class MapboxCircle {
         } else {
             this._currentRadius = Math.min(Math.max(this.options.minRadius, newRadius), this.options.maxRadius);
         }
+        this._eventEmitter.emit('radiuschanging', this);
         this._updateCircle();
         this._animate();
     }


### PR DESCRIPTION
Add two new events: `centerchanging` and `radiuschanging`. They will fire whenever the center/radius of a circle is being changed.
Unlike `centerchanged` and `radiuschanged` which fire only after a `mouseup` or `mouseout`, these will fire every time there is a change during dragging.