### PR TITLE
fixed bug: setCenter to update circle location retained previous lngl…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -565,6 +565,8 @@ class MapboxCircle {
     _onCenterChanged() {
         this._lastCenterLngLat[0] = this.center[0];
         this._lastCenterLngLat[1] = this.center[1];
+        this._editCenterLngLat[0] = this.center[0];
+        this._editCenterLngLat[1] = this.center[1];
     }
 
     /**


### PR DESCRIPTION
…at in _editCenterLngLat causing click on center dot to revert circle to previous location

To reproduce bug:
- npm start
- in example/index.js, comment out setTimeout function lines 103-110, save
- open in browser
- click the white center dot of the upper-left-most circle, editableCircle1 
(if unable to locate just comment out all other circles in js file)
- [bug] the circle will pop back to it's originally initiated lnglat of {lat: 39.984, lng: -75.349} even though it had been set to {lat: 39.989, lng: -75.348} with setCenter, and clicking on the center white dot should not modify the circle, only clicking and dragging should change the center to wherever it is being dragged to.

This pull request fixes aforementioned bug. 👍 
