### PR TITLE
Prevent overlapping mouse down events

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Returns **{sw: {lat: [number](https://developer.mozilla.org/docs/Web/JavaScript/
 ### v. 1.6.7
 
 -   `optionalDependencies` removed from `package.json`, making this package easier to depend on ([#82](https://github.com/smithmicro/mapbox-gl-circle/issues/82))
+-   Bug fix for overlapping mouse-down events, causing the edit handle to lock until the user performs a full page refresh ([#80](https://github.com/smithmicro/mapbox-gl-circle/issues/80))
 
 ### v. 1.6.6
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -501,6 +501,9 @@ class MapboxCircle {
      * @private
      */
     _onCenterHandleMouseDown() {
+        if (this._getCursorStyle() !== 'move') {
+            /* Only trigger center edit event if the user expects it. */ return;
+        }
         this._centerDragActive = true;
         this._mapOnDebounced('mousemove', this._onCenterHandleMouseMove);
         this.map.addLayer(this._getCenterHandleStrokeLayer(), this._circleCenterHandleId);
@@ -640,6 +643,9 @@ class MapboxCircle {
      * @private
      */
     _onRadiusHandlesMouseDown(event) {
+        if (!this._getCursorStyle().endsWith('-resize')) {
+            /* Only trigger radius edit event if the user expects it. */ return;
+        }
         this._radiusDragActive = true;
         this._mapOnDebounced('mousemove', this._onRadiusHandlesMouseMove);
         this.map.addLayer(this._getRadiusHandlesStrokeLayer(), this._circleRadiusHandlesId);
@@ -1113,6 +1119,14 @@ class MapboxCircle {
             paint: this._getEditHandleDefaultPaintOptions(),
             filter: ['==', '$type', 'Point']
         };
+    }
+
+    /**
+     * @return {string} Current cursor style
+     * @private
+     */
+    _getCursorStyle() {
+        return this.map.getCanvas().style.cursor;
     }
 
     /**


### PR DESCRIPTION
When handler drag event overlap, only trigger the drag mouse down event corresponding to the cursor style:
 - `move` -> center handler mouse down event
 - `ns-resize` , `ew-resize` -> radius handler mouse down event

Issue: https://github.com/smithmicro/mapbox-gl-circle/issues/80