### PR TITLE
Finding GHP Rejects Un-Scoped NPM :package: (#93)

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -34,25 +34,32 @@ jobs:
           CHANGELOG_SECTION="### v. $(echo $BUILD_VERSION | cut -d- -f1)"
           echo "Ensure changelog has a '$CHANGELOG_SECTION' section ..." && grep -Fq "$CHANGELOG_SECTION" README.md
 
-          # Build package
+          # Build API documentation
+          npm run docs
+
+          # Build and publish to GHP
+          npm pkg set name=@smithmicro/mapbox-gl-circle
+          npm install
           rm -rf dist/
           npm run browserify
           npm run prepare
-          npm run docs
-
-          # Publish to NPM
-          echo 'registry=https://registry.npmjs.org' >> .npmrc
-          echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' >> .npmrc
-          npm publish --tag=next --access=public
-          git restore .npmrc
-          echo "Pre-release $BUILD_VERSION published to NPM."
-
-          # Publish to GHP
           echo 'registry=https://npm.pkg.github.com' >> .npmrc
           echo '//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}' >> .npmrc
           npm publish --tag=next --access=public
           git restore .npmrc
-          echo "Pre-release $BUILD_VERSION published to GHP."
+          echo "Pre-release @smithmicro/mapbox-gl-circle-$BUILD_VERSION published to GHP."
+
+          # Build and publish to NPM
+          npm pkg set name=mapbox-gl-circle
+          npm install
+          rm -rf dist/
+          npm run browserify
+          npm run prepare
+          echo 'registry=https://registry.npmjs.org' >> .npmrc
+          echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' >> .npmrc
+          npm publish --tag=next --access=public
+          git restore .npmrc
+          echo "Pre-release mapbox-gl-circle-$BUILD_VERSION published to NPM."
 
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,25 +30,32 @@ jobs:
           CHANGELOG_SECTION="### v. $BUILD_VERSION"
           echo "Ensure changelog has a '$CHANGELOG_SECTION' section ..." && grep -Fq "$CHANGELOG_SECTION" README.md
 
-          # Build package
+          # Build API documentation
+          npm run docs
+
+          # Build and publish to GHP
+          npm pkg set name=@smithmicro/mapbox-gl-circle
+          npm install
           rm -rf dist/
           npm run browserify
           npm run prepare
-          npm run docs
-
-          # Publish to NPM
-          echo 'registry=https://registry.npmjs.org' >> .npmrc
-          echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' >> .npmrc
-          npm publish --tag=latest --access=public
-          git restore .npmrc
-          echo "Release $BUILD_VERSION published to NPM."
-
-          # Publish to GHP
           echo 'registry=https://npm.pkg.github.com' >> .npmrc
           echo '//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}' >> .npmrc
           npm publish --tag=latest --access=public
           git restore .npmrc
-          echo "Release $BUILD_VERSION published to GHP."
+          echo "Release @smithmicro/mapbox-gl-circle-$BUILD_VERSION published to GHP."
+
+          # Build and publish to NPM
+          npm pkg set name=mapbox-gl-circle
+          npm install
+          rm -rf dist/
+          npm run browserify
+          npm run prepare
+          echo 'registry=https://registry.npmjs.org' >> .npmrc
+          echo '//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}' >> .npmrc
+          npm publish --tag=latest --access=public
+          git restore .npmrc
+          echo "Release mapbox-gl-circle-$BUILD_VERSION published to NPM."
 
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapbox-gl-circle",
-  "version": "1.6.5",
+  "version": "1.6.6-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mapbox-gl-circle",
-      "version": "1.6.5",
+      "version": "1.6.6-0",
       "license": "ISC",
       "dependencies": {
         "@turf/bbox": "^4.7.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-circle",
-  "version": "1.6.5",
+  "version": "1.6.6-0",
   "author": "Smith Micro Software, Inc.",
   "license": "ISC",
   "description": "A google.maps.Circle replacement for Mapbox GL JS API",


### PR DESCRIPTION
## 🚀 Description

After merging #94, we find that GitHub Packages \[GHP\], does not accept publishing of un-scoped packages. Instead of giving up on GHP entirely, let's publish this under two different names:
1. On NPM, as always, it's the `mapbox-gl-circle` package
2. On GHP, it's the same code as on NPM but published as the "`@smithmicro/mapbox-gl-circle`" package

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
